### PR TITLE
Influxdb plugin

### DIFF
--- a/ConsulAlertingKVBootstrap.py
+++ b/ConsulAlertingKVBootstrap.py
@@ -36,6 +36,7 @@ notify_email= {"mail_domain_address":"",
 notify_pagerduty= {"teams":{}}
 
 notify_influxdb= {"url":"",
+                  "series":"",
                   "databases":{}}
 
 

--- a/ConsulAlertingKVBootstrap.py
+++ b/ConsulAlertingKVBootstrap.py
@@ -35,6 +35,9 @@ notify_email= {"mail_domain_address":"",
 
 notify_pagerduty= {"teams":{}}
 
+notify_influxdb= {"url":"",
+                  "databases":{}}
+
 
 try:
     settings.consul.kv[settings.KV_ALERTING_HEALTH_CHECK_TAGS] = json.dumps(health_check_tags)
@@ -56,6 +59,8 @@ try:
     settings.consul.kv[settings.KV_ALERTING_NOTIFY_EMAIL] = json.dumps(notify_email)
 
     settings.consul.kv[settings.KV_ALERTING_NOTIFY_PAGERDUTY] = json.dumps(notify_pagerduty)
+
+    settings.consul.kv[settings.KV_ALERTING_NOTIFY_INFLUXDB] = json.dumps(notify_influxdb)
 
     settings.consul.kv[settings.KV_PRIOR_STATE] = []
 except TypeError:

--- a/ConsulAlertingKVBootstrap.py
+++ b/ConsulAlertingKVBootstrap.py
@@ -11,7 +11,7 @@ blacklist_checks = []
 health_check_tags = []
 
 
-notify_plugins = ["hipchat","slack","mailgun","email","pagerduty"]
+notify_plugins = ["hipchat","slack","mailgun","email","pagerduty","influxdb"]
 
 notify_hipchat= {"api_token":"",
                  "url":"",

--- a/README.md
+++ b/README.md
@@ -87,6 +87,10 @@ notify_pagerduty = {"teams":{
                    }
 }
 
+notify_influxdb= {"url":"http://localhost:8086/write",
+                  "databases":{"db":"mydb"}
+                 }
+
 ```
 
 | Variable Name | Type | Description |
@@ -158,12 +162,19 @@ After the script is run, you can always change these within the Consul UI
 | ------- | ---- | ----------- |
 | teams | dict | Create dictionaries within 'teams' for tags corresponding to pagerduty teams, value is service_key |
 
+### InfluxDB 0.9
+
+| Keyname | Type | Description |
+| ------- | ---- | ----------- |
+| url | string | URL address of API access for the database |
+| databases | dict | Create dictionaries within 'databases' for tags corresponding to influxdb databases |
+
 # TODO
 * ~~HA, install per leader, using locks and md5sums of state~~
 * ~~Plugin Separation~~
 * ~~Settings as an import instead of inherited~~
 * Cleanup method documentation
-* Influxdb 0.8/0.9 and logstash protocol plugins
+* Influxdb 0.8/~~0.9~~ and logstash protocol plugins
 * ~~Wildcard blacklist~~
 * Improve KVBootstrap.py
 * Integration tests

--- a/README.md
+++ b/README.md
@@ -88,6 +88,7 @@ notify_pagerduty = {"teams":{
 }
 
 notify_influxdb= {"url":"http://localhost:8086/write",
+                  "series":"test",
                   "databases":{"db":"mydb"}
                  }
 
@@ -167,6 +168,7 @@ After the script is run, you can always change these within the Consul UI
 | Keyname | Type | Description |
 | ------- | ---- | ----------- |
 | url | string | URL address of API access for the database |
+| series | string | Name of the database series that will contain the data |
 | databases | dict | Create dictionaries within 'databases' for tags corresponding to influxdb databases |
 
 # TODO

--- a/consulalerting/NotificationEngine.py
+++ b/consulalerting/NotificationEngine.py
@@ -108,7 +108,7 @@ class NotificationEngine(object):
 
         if "influxdb" in configurations_files_to_load:
             self.influxdb = utilities.load_plugin(
-                settings.KV_ALERTING_NOTIFY_INFLUXDB, "database")
+                settings.KV_ALERTING_NOTIFY_INFLUXDB, "databases")
 
         return (self.hipchat, self.slack, self.mailgun,
                 self.email, self.pagerduty, self.influxdb)
@@ -181,8 +181,11 @@ class NotificationEngine(object):
                                                            pagerduty)).start()
 
         if "influxdb" in obj.Tags and self.influxdb:
+            common_notifiers = utilities.common_notifiers(
+                obj, "databases", self.influxdb)
             influxdb = self.influxdb
             _ = Process(target=plugins.notify_influxdb, args=(obj, message_template,
+                                                         common_notifiers,
                                                          influxdb)).start()
 
     def Run(self):

--- a/consulalerting/NotificationEngine.py
+++ b/consulalerting/NotificationEngine.py
@@ -143,7 +143,7 @@ class NotificationEngine(object):
             common_notifiers = utilities.common_notifiers(
                 obj, "rooms", self.hipchat)
             hipchat = self.hipchat
-            Process(target=plugins.notify_hipchat, args=(obj, message_template,
+            _ = Process(target=plugins.notify_hipchat, args=(obj, message_template,
                                                          common_notifiers,
                                                          hipchat)).start()
 
@@ -182,7 +182,7 @@ class NotificationEngine(object):
 
         if "influxdb" in obj.Tags and self.influxdb:
             influxdb = self.influxdb
-            Process(target=plugins.notify_influxdb, args=(obj, message_template,
+            _ = Process(target=plugins.notify_influxdb, args=(obj, message_template,
                                                          influxdb)).start()
 
     def Run(self):

--- a/consulalerting/NotificationEngine.py
+++ b/consulalerting/NotificationEngine.py
@@ -106,8 +106,12 @@ class NotificationEngine(object):
             self.pagerduty = utilities.load_plugin(
                 settings.KV_ALERTING_NOTIFY_PAGERDUTY, "teams")
 
+        if "influxdb" in configurations_files_to_load:
+            self.influxdb = utilities.load_plugin(
+                settings.KV_ALERTING_NOTIFY_INFLUXDB, "database")
+
         return (self.hipchat, self.slack, self.mailgun,
-                self.email, self.pagerduty)
+                self.email, self.pagerduty, self.influxdb)
 
     def message_pattern(self, obj):
 
@@ -175,6 +179,11 @@ class NotificationEngine(object):
                                                            message_template,
                                                            common_notifiers,
                                                            pagerduty)).start()
+
+        if "influxdb" in obj.Tags and self.influxdb:
+            influxdb = self.influxdb
+            Process(target=plugins.notify_influxdb, args=(obj, message_template,
+                                                         influxdb)).start()
 
     def Run(self):
         self.get_available_plugins()

--- a/consulalerting/plugins.py
+++ b/consulalerting/plugins.py
@@ -208,7 +208,10 @@ def notify_pagerduty(
 def notify_influxdb(obj, message_template, common_notifiers, consul_influxdb):
     for database in common_notifiers:
 
-        message_template = 'new value="{msg}"'.format(msg=message_template)
+        message_template = '{series} value="{msg}"'.format(
+            series=consul_influxdb["series"],
+            msg=message_template)
+
         response = requests.post(
             consul_influxdb["url"],
             params={'db': consul_influxdb["databases"][database]},

--- a/consulalerting/plugins.py
+++ b/consulalerting/plugins.py
@@ -203,3 +203,35 @@ def notify_pagerduty(
                 "Status_Code={status}".format(message=message_template,
                                               status=response.status_code))
             return response.status_code
+
+
+def notify_influxdb(obj, message_template, consul_influxdb):
+    # message_template = "test value={msg}".format(msg=message_template)
+    message_template = "test value=1"
+    response = requests.post(
+        consul_influxdb["url"],
+        params={'db': consul_influxdb["database"]},
+        data=message_template)
+
+    if response.status_code == 200:
+        settings.logger.info(
+            "NotifyPlugin=InfluxDB Server={url} "
+            "Database={database} Message={message} "
+            "Status_Code={status}".format(
+                url=consul_influxdb["url"],
+                database=consul_influxdb["database"],
+                message=message_template,
+                status=response.status_code))
+
+        return response.status_code
+    else:
+        settings.logger.error(
+            "NotifyPlugin=InfluxDB Server={url} "
+            "Database={database} Message={message} "
+            "Status_Code={status}".format(
+                url=consul_influxdb["url"],
+                database=consul_influxdb["database"],
+                message=message_template,
+                status=response.status_code))
+
+        return response.status_code

--- a/consulalerting/plugins.py
+++ b/consulalerting/plugins.py
@@ -207,9 +207,8 @@ def notify_pagerduty(
 
 def notify_influxdb(obj, message_template, common_notifiers, consul_influxdb):
     for database in common_notifiers:
-        
-        # message_template = "test value={msg}".format(msg=message_template)
-        message_template = "test value=1"
+
+        message_template = 'new value="{msg}"'.format(msg=message_template)
         response = requests.post(
             consul_influxdb["url"],
             params={'db': consul_influxdb["databases"][database]},

--- a/consulalerting/plugins.py
+++ b/consulalerting/plugins.py
@@ -205,33 +205,35 @@ def notify_pagerduty(
             return response.status_code
 
 
-def notify_influxdb(obj, message_template, consul_influxdb):
-    # message_template = "test value={msg}".format(msg=message_template)
-    message_template = "test value=1"
-    response = requests.post(
-        consul_influxdb["url"],
-        params={'db': consul_influxdb["database"]},
-        data=message_template)
+def notify_influxdb(obj, message_template, common_notifiers, consul_influxdb):
+    for database in common_notifiers:
+        
+        # message_template = "test value={msg}".format(msg=message_template)
+        message_template = "test value=1"
+        response = requests.post(
+            consul_influxdb["url"],
+            params={'db': consul_influxdb["databases"][database]},
+            data=message_template)
 
-    if response.status_code == 200:
-        settings.logger.info(
-            "NotifyPlugin=InfluxDB Server={url} "
-            "Database={database} Message={message} "
-            "Status_Code={status}".format(
-                url=consul_influxdb["url"],
-                database=consul_influxdb["database"],
-                message=message_template,
-                status=response.status_code))
+        if response.status_code == 200:
+            settings.logger.info(
+                "NotifyPlugin=InfluxDB Server={url} "
+                "Database={database} Message={message} "
+                "Status_Code={status}".format(
+                    url=consul_influxdb["url"],
+                    database=consul_influxdb["databases"][database],
+                    message=message_template,
+                    status=response.status_code))
 
-        return response.status_code
-    else:
-        settings.logger.error(
-            "NotifyPlugin=InfluxDB Server={url} "
-            "Database={database} Message={message} "
-            "Status_Code={status}".format(
-                url=consul_influxdb["url"],
-                database=consul_influxdb["database"],
-                message=message_template,
-                status=response.status_code))
+            return response.status_code
+        else:
+            settings.logger.error(
+                "NotifyPlugin=InfluxDB Server={url} "
+                "Database={database} Message={message} "
+                "Status_Code={status}".format(
+                    url=consul_influxdb["url"],
+                    database=consul_influxdb["databases"][database],
+                    message=message_template,
+                    status=response.status_code))
 
-        return response.status_code
+            return response.status_code

--- a/consulalerting/plugins.py
+++ b/consulalerting/plugins.py
@@ -208,8 +208,14 @@ def notify_pagerduty(
 def notify_influxdb(obj, message_template, common_notifiers, consul_influxdb):
     for database in common_notifiers:
 
-        message_template = '{series} value="{msg}"'.format(
+        tags = 'ServiceID={ServiceID},CheckID={CheckID},Status={Status}'.format(
+            ServiceID=obj.ServiceID,
+            CheckID=obj.CheckID,
+            Status=obj.Status)
+
+        message_template = '{series},{tags} value="{msg}"'.format(
             series=consul_influxdb["series"],
+            tags=tags,
             msg=message_template)
 
         response = requests.post(

--- a/consulalerting/plugins.py
+++ b/consulalerting/plugins.py
@@ -208,6 +208,8 @@ def notify_pagerduty(
 def notify_influxdb(obj, message_template, common_notifiers, consul_influxdb):
     for database in common_notifiers:
 
+        message_template = message_template.replace('\n', ' ')
+
         tags = 'ServiceID={ServiceID},CheckID={CheckID},Status={Status}'.format(
             ServiceID=obj.ServiceID,
             CheckID=obj.CheckID,

--- a/consulalerting/settings.py
+++ b/consulalerting/settings.py
@@ -15,6 +15,7 @@ KV_ALERTING_NOTIFY_SLACK = "alerting/notify/slack"
 KV_ALERTING_NOTIFY_MAILGUN = "alerting/notify/mailgun"
 KV_ALERTING_NOTIFY_EMAIL = "alerting/notify/email"
 KV_ALERTING_NOTIFY_PAGERDUTY = "alerting/notify/pagerduty"
+KV_ALERTING_NOTIFY_INFLUXDB = "alerting/notify/influxdb"
 
 KV_PRIOR_STATE = "alerting/prior"
 KV_ALERTING_HASHES = "alerting/hashes"

--- a/tests/test_NotificationEngine.py
+++ b/tests/test_NotificationEngine.py
@@ -67,12 +67,13 @@ class NotificationEngineTests(unittest.TestCase):
             ["devops", "consul", "mailgun", "hipchat", "redis", "techops", "dev", "slack", "qa", "redis-slave"])))
 
     def test_loadPluginsFromTags(self):
-        hipchat, slack, mailgun, email, pagerduty = self.ne.load_plugins_from_tags()
+        hipchat, slack, mailgun, email, pagerduty, influxdb = self.ne.load_plugins_from_tags()
         self.assertFalse(email)
         self.assertTrue(hipchat)
         self.assertFalse(slack)
         self.assertTrue(mailgun)
         self.assertFalse(pagerduty)
+        self.assertFalse(influxdb)
 
 
 if __name__ == '__main__':

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -39,7 +39,7 @@ CONSUL_MAILGUN = {"api_token": "testing123testing123",
 
 CONSUL_PAGERDUTY = {"teams": {"devops": ""}}
 
-CONSUL_INFLUXDB = {"url":"http://localhost:8086/write", "databases":{"db":"mydb"}}
+CONSUL_INFLUXDB = {"url":"http://localhost:8086/write", "series":"test", "databases":{"db":"mydb"}}
 
 
 class PluginsTests(unittest.TestCase):

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -13,7 +13,7 @@ ALL_REQUESTS_ALERTING_AVAILABLE_PLUGINS = [
 ALL_REQUESTS_PLUGINS_ALERT_LIST = [{"Node": "consul",
                                     "CheckID": "service:redis",
                                     "Name": "Service 'redis' check",
-                                    "Tags": ["hipchat", "slack", "mailgun", "pagerduty", "influxdb", "devops"],
+                                    "Tags": ["hipchat", "slack", "mailgun", "pagerduty", "influxdb", "devops", "db"],
                                     "ServiceName": "redis",
                                     "Notes": "",
                                     "Status": "critical",


### PR DESCRIPTION
This is an influxdb plugin similar to the existing plugins.  It utilizes the influxdb REST API to store consul alerts into a database series.