### PR TITLE
Added a cleanup call that releases lock at the end of execution.

### DIFF
--- a/consulalerting/utilities.py
+++ b/consulalerting/utilities.py
@@ -74,6 +74,11 @@ def acquireLock(key, session_id):
     return settings.consul.kv.acquire_lock(key, session_id)
 
 
+def releaseLock(key, session_id):
+
+    return settings.consul.kv.release_lock(key, session_id)
+
+
 def getBlacklist(key):
 
     try:


### PR DESCRIPTION
We found that when watch handler was acquiring the lock, it did not unlock before exit. The handler was relying on a 10-second lock timeout. This caused some events to get lost, especially when services were flapping between healthy/unhealthy at rates higher than once per 10 seconds. Adding explicit unlocking resolved the issue and we were able to track flapping services within our infrastructure.