### PR TITLE
Plugin: Elasticsearch Logging

### DIFF
--- a/ConsulAlertingKVBootstrap.py
+++ b/ConsulAlertingKVBootstrap.py
@@ -40,7 +40,7 @@ notify_influxdb = {"url": "",
                    "databases": {}
                    }
 
-notify_elasticsearchlog = {"logpaths": []}
+notify_elasticsearchlog = {"logpath": ""}
 
 
 try:

--- a/ConsulAlertingKVBootstrap.py
+++ b/ConsulAlertingKVBootstrap.py
@@ -40,10 +40,7 @@ notify_influxdb = {"url": "",
                    "databases": {}
                    }
 
-notify_elasticsearchlog = {"logpaths": [],
-                           "logmode": "a",
-                           "newlinecharacter": "\n"
-                           }
+notify_elasticsearchlog = {"logpaths": []}
 
 
 try:

--- a/ConsulAlertingKVBootstrap.py
+++ b/ConsulAlertingKVBootstrap.py
@@ -7,37 +7,43 @@ blacklist_nodes = []
 blacklist_services = []
 blacklist_checks = []
 
-
 health_check_tags = []
 
+notify_plugins = ["hipchat", "slack", "mailgun", "email", "pagerduty", "influxdb", "elasticsearchlog"]
 
-notify_plugins = ["hipchat","slack","mailgun","email","pagerduty","influxdb"]
+notify_hipchat = {"api_token": "",
+                  "url": "",
+                  "rooms": {}
+                  }
 
-notify_hipchat= {"api_token":"",
-                 "url":"",
-                 "rooms":{}}
-
-notify_slack= {"api_token":"",
-                 "rooms":{}}
-
-notify_mailgun= {"api_token":"",
-                 "mailgun_domain":"",
-                 "from": "",
-                 "teams":{}
-                 }
-
-notify_email= {"mail_domain_address":"",
-               "username":"",
-               "password":"",
-               "from": "",
-               "teams":{}
+notify_slack = {"api_token": "",
+                "rooms": {}
                 }
 
-notify_pagerduty= {"teams":{}}
+notify_mailgun = {"api_token": "",
+                  "mailgun_domain": "",
+                  "from": "",
+                  "teams": {}
+                  }
 
-notify_influxdb= {"url":"",
-                  "series":"",
-                  "databases":{}}
+notify_email = {"mail_domain_address": "",
+                "username": "",
+                "password": "",
+                "from": "",
+                "teams": {}
+                }
+
+notify_pagerduty = {"teams": {}}
+
+notify_influxdb = {"url": "",
+                   "series": "",
+                   "databases": {}
+                   }
+
+notify_elasticsearchlog = {"logpaths": [],
+                           "logmode": "a",
+                           "newlinecharacter": "\n"
+                           }
 
 
 try:
@@ -63,11 +69,9 @@ try:
 
     settings.consul.kv[settings.KV_ALERTING_NOTIFY_INFLUXDB] = json.dumps(notify_influxdb)
 
+    settings.consul.kv[settings.KV_ALERTING_NOTIFY_ELASTICSEARCHLOG] = json.dumps(notify_elasticsearchlog)
+
     settings.consul.kv[settings.KV_PRIOR_STATE] = []
 except TypeError:
     print "One of the python data structures is not JSON serializable, may have accidentally created a set()"
     raise
-
-
-
-

--- a/README.md
+++ b/README.md
@@ -90,10 +90,7 @@ notify_influxdb= {"url":"http://localhost:8086/write",
                   "databases":{"db":"mydb"}
                  }
 
-notify_elasticsearchlog = {"logpaths": ["/path/to/log1"],
-                           "logmode": "a",
-                           "newlinecharacter": "\n"
-                           }
+notify_elasticsearchlog = {"logpaths": ["/path/to/log1"]}
 ```
 
 | Variable Name | Type | Description |

--- a/README.md
+++ b/README.md
@@ -49,10 +49,6 @@ the scripts can obtain the necessary KV information from Consul.
 
 ## Example ConsulAlertingKVBoostrap.py
 ```python
-
-
-
-
 blacklist_nodes = ["fqdn","other_fqdn"]
 blacklist_services = ["redis"]
 blacklist_checks = ["service:redis"]
@@ -94,6 +90,10 @@ notify_influxdb= {"url":"http://localhost:8086/write",
                   "databases":{"db":"mydb"}
                  }
 
+notify_elasticsearchlog = {"logpaths": ["/path/to/log1"],
+                           "logmode": "a",
+                           "newlinecharacter": "\n"
+                           }
 ```
 
 | Variable Name | Type | Description |

--- a/consulalerting/NotificationEngine.py
+++ b/consulalerting/NotificationEngine.py
@@ -111,8 +111,7 @@ class NotificationEngine(object):
                 settings.KV_ALERTING_NOTIFY_INFLUXDB, "databases")
 
         if "elasticsearchlog" in configurations_files_to_load:
-            self.elasticsearchlog = utilities.load_plugin(
-                settings.KV_ALERTING_NOTIFY_ELASTICSEARCHLOG, "logpaths")
+            self.elasticsearchlog = settings.KV_ALERTING_NOTIFY_ELASTICSEARCHLOG["logpath"]
 
         return (self.hipchat, self.slack, self.mailgun,
                 self.email, self.pagerduty, self.influxdb, self.elasticsearchlog)
@@ -193,10 +192,8 @@ class NotificationEngine(object):
                                                          influxdb)).start()
 
         if "elasticsearchlog" in obj.Tags and self.elasticsearchlog:
-            common_notifiers = utilities.common_notifiers(obj, "logpaths", self.elasticsearchlog)
-            elasticsearchlog = self.elasticsearchlog
             _ = Process(target=plugins.notify_elasticsearchlog, args=(obj, message_template,
-                                                                      common_notifiers, elasticsearchlog)).start()
+                                                                      self.elasticsearchlog)).start()
 
     def Run(self):
         self.get_available_plugins()

--- a/consulalerting/NotificationEngine.py
+++ b/consulalerting/NotificationEngine.py
@@ -110,8 +110,12 @@ class NotificationEngine(object):
             self.influxdb = utilities.load_plugin(
                 settings.KV_ALERTING_NOTIFY_INFLUXDB, "databases")
 
+        if "elasticsearchlog" in configurations_files_to_load:
+            self.elasticsearchlog = utilities.load_plugin(
+                settings.KV_ALERTING_NOTIFY_ELASTICSEARCHLOG, "logpaths")
+
         return (self.hipchat, self.slack, self.mailgun,
-                self.email, self.pagerduty, self.influxdb)
+                self.email, self.pagerduty, self.influxdb, self.elasticsearchlog)
 
     def message_pattern(self, obj):
 
@@ -187,6 +191,12 @@ class NotificationEngine(object):
             _ = Process(target=plugins.notify_influxdb, args=(obj, message_template,
                                                          common_notifiers,
                                                          influxdb)).start()
+
+        if "elasticsearchlog" in obj.Tags and self.elasticsearchlog:
+            common_notifiers = utilities.common_notifiers(obj, "logs", self.elasticsearchlog)
+            elasticsearchlog = self.elasticsearchlog
+            _ = Process(target=plugins.notify_elasticsearchlog, args=(obj, message_template,
+                                                                      common_notifiers, elasticsearchlog)).start()
 
     def Run(self):
         self.get_available_plugins()

--- a/consulalerting/NotificationEngine.py
+++ b/consulalerting/NotificationEngine.py
@@ -111,7 +111,8 @@ class NotificationEngine(object):
                 settings.KV_ALERTING_NOTIFY_INFLUXDB, "databases")
 
         if "elasticsearchlog" in configurations_files_to_load:
-            self.elasticsearchlog = settings.KV_ALERTING_NOTIFY_ELASTICSEARCHLOG["logpath"]
+            self.elasticsearchlog = utilities.load_plugin(
+                settings.KV_ALERTING_NOTIFY_ELASTICSEARCHLOG)
 
         return (self.hipchat, self.slack, self.mailgun,
                 self.email, self.pagerduty, self.influxdb, self.elasticsearchlog)

--- a/consulalerting/NotificationEngine.py
+++ b/consulalerting/NotificationEngine.py
@@ -193,7 +193,7 @@ class NotificationEngine(object):
                                                          influxdb)).start()
 
         if "elasticsearchlog" in obj.Tags and self.elasticsearchlog:
-            common_notifiers = utilities.common_notifiers(obj, "logs", self.elasticsearchlog)
+            common_notifiers = utilities.common_notifiers(obj, "logpaths", self.elasticsearchlog)
             elasticsearchlog = self.elasticsearchlog
             _ = Process(target=plugins.notify_elasticsearchlog, args=(obj, message_template,
                                                                       common_notifiers, elasticsearchlog)).start()

--- a/consulalerting/plugins.py
+++ b/consulalerting/plugins.py
@@ -266,9 +266,9 @@ def notify_elasticsearchlog(obj, message_template, common_notifiers, consul_elas
 
     for logpath in common_notifiers:
         try:
-            with open(logpath, consul_elasticsearchlog["logmode"]) as elasticsearchlog:
+            with open(logpath, "a") as elasticsearchlog:
                 json.dump(logdata, elasticsearchlog)
-                elasticsearchlog.write(consul_elasticsearchlog["newlinecharacter"])
+                elasticsearchlog.write("\n")
 
         except IOError, es_log_error:
             settings.logger.error("There was an issue writing to {logpath}: {error}".format(logpath=logpath,

--- a/consulalerting/plugins.py
+++ b/consulalerting/plugins.py
@@ -265,7 +265,7 @@ def notify_elasticsearchlog(obj, message_template, es_logpath):
                }
 
     try:
-        with open(es_logpath, "a") as elasticsearchlog:
+        with open(es_logpath["logpath"], "a") as elasticsearchlog:
             json.dump(logdata, elasticsearchlog)
             elasticsearchlog.write("\n")
 

--- a/consulalerting/plugins.py
+++ b/consulalerting/plugins.py
@@ -250,7 +250,7 @@ def notify_influxdb(obj, message_template, common_notifiers, consul_influxdb):
             return response.status_code
 
 
-def notify_elasticsearchlog(obj, message_template, common_notifiers, consul_elasticsearchlog):
+def notify_elasticsearchlog(obj, message_template, es_logpath):
 
     logdata = {"@timestamp": datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
                "Message": message_template.replace('\n', ' '),
@@ -264,12 +264,11 @@ def notify_elasticsearchlog(obj, message_template, common_notifiers, consul_elas
                "ServiceName": obj.ServiceName
                }
 
-    for logpath in common_notifiers:
-        try:
-            with open(logpath, "a") as elasticsearchlog:
-                json.dump(logdata, elasticsearchlog)
-                elasticsearchlog.write("\n")
+    try:
+        with open(es_logpath, "a") as elasticsearchlog:
+            json.dump(logdata, elasticsearchlog)
+            elasticsearchlog.write("\n")
 
-        except IOError, es_log_error:
-            settings.logger.error("There was an issue writing to {logpath}: {error}".format(logpath=logpath,
-                                                                                            error=es_log_error))
+    except IOError, es_log_error:
+        settings.logger.error("There was an issue writing to {logpath}: {error}".format(logpath=es_logpath,
+                                                                                        error=es_log_error))

--- a/consulalerting/plugins.py
+++ b/consulalerting/plugins.py
@@ -3,6 +3,7 @@ import settings
 import smtplib
 import string
 import json as json
+from datetime import datetime
 
 def notify_hipchat(obj, message_template, common_notifiers, consul_hipchat):
     notify_value = 0
@@ -247,3 +248,28 @@ def notify_influxdb(obj, message_template, common_notifiers, consul_influxdb):
                     status=response.status_code))
 
             return response.status_code
+
+
+def notify_elasticsearchlog(obj, message_template, common_notifiers, consul_elasticsearchlog):
+
+    logdata = {"@timestamp": datetime.now().strftime("%Y-%m-%dT%H:%M:%S"),
+               "Message": message_template.replace('\n', ' '),
+               "Node": obj.Node,
+               "CheckID": obj.CheckID,
+               "Name": obj.Name,
+               "Tags": ', '.join(obj.Tags),
+               "Notes": obj.Notes,
+               "Output": obj.Output,
+               "ServiceID": obj.ServiceID,
+               "ServiceName": obj.ServiceName
+               }
+
+    for logpath in common_notifiers:
+        try:
+            with open(logpath, consul_elasticsearchlog["logmode"]) as elasticsearchlog:
+                json.dump(logdata, elasticsearchlog)
+                elasticsearchlog.write(consul_elasticsearchlog["newlinecharacter"])
+
+        except IOError, es_log_error:
+            settings.logger.error("There was an issue writing to {logpath}: {error}".format(logpath=logpath,
+                                                                                            error=es_log_error))

--- a/consulalerting/settings.py
+++ b/consulalerting/settings.py
@@ -16,6 +16,7 @@ KV_ALERTING_NOTIFY_MAILGUN = "alerting/notify/mailgun"
 KV_ALERTING_NOTIFY_EMAIL = "alerting/notify/email"
 KV_ALERTING_NOTIFY_PAGERDUTY = "alerting/notify/pagerduty"
 KV_ALERTING_NOTIFY_INFLUXDB = "alerting/notify/influxdb"
+KV_ALERTING_NOTIFY_ELASTICSEARCHLOG = "alerting/notify/elasticsearchlog"
 
 KV_PRIOR_STATE = "alerting/prior"
 KV_ALERTING_HASHES = "alerting/hashes"

--- a/consulalerting/utilities.py
+++ b/consulalerting/utilities.py
@@ -129,7 +129,7 @@ def common_notifiers(obj, kv_tags_dictname, kv_dict):
     return common
 
 
-def load_plugin(KV_LOCATION, tags_dictname):
+def load_plugin(KV_LOCATION, tags_dictname=None):
     # get request to 0.0.0.0:8500/v1/kv/notify/<plugin_name>
     #  which routes to consul master
     plugin = json.loads(settings.consul.kv[KV_LOCATION])
@@ -137,8 +137,9 @@ def load_plugin(KV_LOCATION, tags_dictname):
     # Convert Keys to lower case
     plugin = _dict_keys_to_low(plugin)
 
-    plugin[tags_dictname] = dict((key.lower(), value) for key,
-                                 value in plugin[tags_dictname].iteritems())
+    if tags_dictname:
+        plugin[tags_dictname] = dict((key.lower(), value) for key,
+                                     value in plugin[tags_dictname].iteritems())
 
     return plugin
 

--- a/tests/test_NotificationEngine.py
+++ b/tests/test_NotificationEngine.py
@@ -67,13 +67,14 @@ class NotificationEngineTests(unittest.TestCase):
             ["devops", "consul", "mailgun", "hipchat", "redis", "techops", "dev", "slack", "qa", "redis-slave"])))
 
     def test_loadPluginsFromTags(self):
-        hipchat, slack, mailgun, email, pagerduty, influxdb = self.ne.load_plugins_from_tags()
+        hipchat, slack, mailgun, email, pagerduty, influxdb, elasticsearchlog = self.ne.load_plugins_from_tags()
         self.assertFalse(email)
         self.assertTrue(hipchat)
         self.assertFalse(slack)
         self.assertTrue(mailgun)
         self.assertFalse(pagerduty)
         self.assertFalse(influxdb)
+        self.assertFalse(elasticsearchlog)
 
 
 if __name__ == '__main__':

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -5,6 +5,7 @@ import consulalerting.plugins as plugins
 import consulalerting.settings as settings
 import consulalerting.utilities as utilities
 import consulalerting.ConsulHealthStruct as ConsulHealthStruct
+from mock import patch, MagicMock, Mock
 
 
 ALL_REQUESTS_ALERTING_AVAILABLE_PLUGINS = [
@@ -40,6 +41,8 @@ CONSUL_MAILGUN = {"api_token": "testing123testing123",
 CONSUL_PAGERDUTY = {"teams": {"devops": ""}}
 
 CONSUL_INFLUXDB = {"url":"http://localhost:8086/write", "series":"test", "databases":{"db":"mydb"}}
+
+CONSUL_ELASTICSEARCHLOG = {"logpaths": ["/path/to/log1", "/path/to/log2"], "logmode": "a", "newlinecharacter": "\n"}
 
 
 class PluginsTests(unittest.TestCase):
@@ -172,3 +175,13 @@ class PluginsTests(unittest.TestCase):
             self.obj, self.message_template, ["db"], CONSUL_INFLUXDB)
 
         self.assertNotEqual(204, status_code)
+
+    def test_notifyElasticSearchLog(self):
+        open_mock = MagicMock()
+        with patch('__builtin__.open', open_mock):
+            open_mock.return_value = MagicMock(spec=file)
+            plugins.notify_elasticsearchlog(self.obj, self.message_template, CONSUL_ELASTICSEARCHLOG["logpaths"],
+                                            CONSUL_ELASTICSEARCHLOG)
+
+        file_handle = open_mock.return_value.__enter__.return_value
+        file_handle.write.assert_called_with(CONSUL_ELASTICSEARCHLOG["newlinecharacter"])

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -42,7 +42,7 @@ CONSUL_PAGERDUTY = {"teams": {"devops": ""}}
 
 CONSUL_INFLUXDB = {"url":"http://localhost:8086/write", "series":"test", "databases":{"db":"mydb"}}
 
-CONSUL_ELASTICSEARCHLOG = {"logpaths": ["/path/to/log1", "/path/to/log2"], "logmode": "a", "newlinecharacter": "\n"}
+CONSUL_ELASTICSEARCHLOG = {"logpaths": ["/path/to/log1", "/path/to/log2"]}
 
 
 class PluginsTests(unittest.TestCase):
@@ -184,4 +184,4 @@ class PluginsTests(unittest.TestCase):
                                             CONSUL_ELASTICSEARCHLOG)
 
         file_handle = open_mock.return_value.__enter__.return_value
-        file_handle.write.assert_called_with(CONSUL_ELASTICSEARCHLOG["newlinecharacter"])
+        file_handle.write.assert_called_with("\n")

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -42,7 +42,7 @@ CONSUL_PAGERDUTY = {"teams": {"devops": ""}}
 
 CONSUL_INFLUXDB = {"url":"http://localhost:8086/write", "series":"test", "databases":{"db":"mydb"}}
 
-CONSUL_ELASTICSEARCHLOG = {"logpaths": ["/path/to/log1", "/path/to/log2"]}
+CONSUL_ELASTICSEARCHLOG = {"logpath": "/path/to/log"}
 
 
 class PluginsTests(unittest.TestCase):
@@ -180,8 +180,7 @@ class PluginsTests(unittest.TestCase):
         open_mock = MagicMock()
         with patch('__builtin__.open', open_mock):
             open_mock.return_value = MagicMock(spec=file)
-            plugins.notify_elasticsearchlog(self.obj, self.message_template, CONSUL_ELASTICSEARCHLOG["logpaths"],
-                                            CONSUL_ELASTICSEARCHLOG)
+            plugins.notify_elasticsearchlog(self.obj, self.message_template, CONSUL_ELASTICSEARCHLOG["logpath"])
 
         file_handle = open_mock.return_value.__enter__.return_value
         file_handle.write.assert_called_with("\n")

--- a/tests/test_plugins.py
+++ b/tests/test_plugins.py
@@ -180,7 +180,7 @@ class PluginsTests(unittest.TestCase):
         open_mock = MagicMock()
         with patch('__builtin__.open', open_mock):
             open_mock.return_value = MagicMock(spec=file)
-            plugins.notify_elasticsearchlog(self.obj, self.message_template, CONSUL_ELASTICSEARCHLOG["logpath"])
+            plugins.notify_elasticsearchlog(self.obj, self.message_template, CONSUL_ELASTICSEARCHLOG)
 
         file_handle = open_mock.return_value.__enter__.return_value
         file_handle.write.assert_called_with("\n")


### PR DESCRIPTION
This plugin adds the ability to write events to a JSON log that can be forwarded to Elasticsearch. For all intents, it's a JSON log plugin, but I've specifically named it for Elasticsearch because of the `@timestamp` syntax used in `logdata`.

Please let me know if you'd prefer the plugin name be a bit more generic, or if you have any other suggestions :smile: 