### PR TITLE
The ability for Consul to report incidents to Cachet

### DIFF
--- a/ConsulAlertingKVBootstrap.py
+++ b/ConsulAlertingKVBootstrap.py
@@ -9,7 +9,7 @@ blacklist_checks = []
 
 health_check_tags = []
 
-notify_plugins = ["hipchat", "slack", "mailgun", "email", "pagerduty", "influxdb", "elasticsearchlog"]
+notify_plugins = ["hipchat", "slack", "mailgun", "email", "pagerduty", "influxdb", "elasticsearchlog", "cachet"]
 
 notify_hipchat = {"api_token": "",
                   "url": "",
@@ -42,6 +42,11 @@ notify_influxdb = {"url": "",
 
 notify_elasticsearchlog = {"logpath": ""}
 
+notify_cachet = {"api_token": "",
+                 "site_url": "",
+                 "notify_subscribers": ""
+                 }
+
 
 try:
     settings.consul.kv[settings.KV_ALERTING_HEALTH_CHECK_TAGS] = json.dumps(health_check_tags)
@@ -67,6 +72,8 @@ try:
     settings.consul.kv[settings.KV_ALERTING_NOTIFY_INFLUXDB] = json.dumps(notify_influxdb)
 
     settings.consul.kv[settings.KV_ALERTING_NOTIFY_ELASTICSEARCHLOG] = json.dumps(notify_elasticsearchlog)
+
+    settings.consul.kv[settings.KV_ALERTING_NOTIFY_CACHET] = json.dumps(notify_cachet)
 
     settings.consul.kv[settings.KV_PRIOR_STATE] = []
 except TypeError:

--- a/README.md
+++ b/README.md
@@ -91,6 +91,11 @@ notify_influxdb= {"url":"http://localhost:8086/write",
                  }
 
 notify_elasticsearchlog = {"logpaths": ["/path/to/log1"]}
+
+notify_cachet = {"api_token": "tokenFromCachetUserProfile",
+                 "site_url": "http://status.company.com",
+                 "notify_subscribers": False
+                }
 ```
 
 | Variable Name | Type | Description |
@@ -175,6 +180,16 @@ After the script is run, you can always change these within the Consul UI
 | Keyname | Type | Description |
 | ------- | ---- | ----------- |
 | logpath | array of strings | Absolute path(s) of logfile to write in elasticsearch format |
+
+### Cachet
+
+| Keyname | Type | Description |
+| ------- | ---- | ----------- |
+| api_token | string | The API token provided by Cachet via a user profile page |
+| site_url | string | The url of the Cachet instance |
+| notify_subscribers | boolean | Whether or not subscribers should be notified of the incident |
+
+__NOTE:__ In order for this plugin to report Cachet incidents to specific components, it is expected that in addition to the `cachet` tag you also provide a "service nice name" as a tag. For example, if in Cachet your component is called "Data Import Service" you would then provided that same string as a tag in your service definition. If a matching tag is not found incidents will be reported with a generic name of "Consul State Change."
 
 # TODO
 * ~~HA, install per leader, using locks and md5sums of state~~

--- a/consulalerting/NotificationEngine.py
+++ b/consulalerting/NotificationEngine.py
@@ -110,6 +110,10 @@ class NotificationEngine(object):
             self.influxdb = utilities.load_plugin(
                 settings.KV_ALERTING_NOTIFY_INFLUXDB, "databases")
 
+        if "cachet" in configurations_files_to_load:
+            self.cachet = utilities.load_plugin(
+                settings.KV_ALERTING_NOTIFY_CACHET)
+
         if "elasticsearchlog" in configurations_files_to_load:
             self.elasticsearchlog = utilities.load_plugin(
                 settings.KV_ALERTING_NOTIFY_ELASTICSEARCHLOG)
@@ -191,6 +195,9 @@ class NotificationEngine(object):
             _ = Process(target=plugins.notify_influxdb, args=(obj, message_template,
                                                          common_notifiers,
                                                          influxdb)).start()
+
+        if "cachet" in obj.Tags and self.cachet:
+            _ = Process(target=plugins.notify_cache, args=(obj, message_template, self.cachet)).start()
 
         if "elasticsearchlog" in obj.Tags and self.elasticsearchlog:
             _ = Process(target=plugins.notify_elasticsearchlog, args=(obj, message_template,

--- a/consulalerting/settings.py
+++ b/consulalerting/settings.py
@@ -17,6 +17,7 @@ KV_ALERTING_NOTIFY_EMAIL = "alerting/notify/email"
 KV_ALERTING_NOTIFY_PAGERDUTY = "alerting/notify/pagerduty"
 KV_ALERTING_NOTIFY_INFLUXDB = "alerting/notify/influxdb"
 KV_ALERTING_NOTIFY_ELASTICSEARCHLOG = "alerting/notify/elasticsearchlog"
+KV_ALERTING_NOTIFY_CACHET = "alerting/notify/cachet"
 
 KV_PRIOR_STATE = "alerting/prior"
 KV_ALERTING_HASHES = "alerting/hashes"

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup
 
 setup(
     name="consulalerting",
-    version="0.0.4",
+    version="0.0.5",
     description="A set of python files for Consul for checks, watches, and notifications",
     url="https://github.com/jrxFive/Consul-Alerting",
     author="Jonathan R. Cross",


### PR DESCRIPTION
[Cachet](https://cachethq.io/) is an open source status page system. This change adds the ability for consulalerting to communicate Consul state changes to Cachet as incidents.

This pull request increments consulalerting to version `0.0.5`.

### Required KVs

- api_token: The API token provided by Cachet via a user profile page
- site_url: The URL of the Cachet instance
- notify_subscribers: A boolean for whether or not subscribers should be notified of incidents

### Component specific incident reporting

The plugin relies on the ability to match provided Consul tags to Cachet components. Upon successful match the incident will be reported specifically for that component.

__For example:__
If a Component in Cachet is setup with the name _Data Import Service_ the Consul tags would be `["cachet", "Data Import Service"]`